### PR TITLE
Added support for zig pkg manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zig-cache/
+zig-out/

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,10 @@ pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const mode = b.standardOptimizeOption(.{});
 
+    const fsm_mod = b.addModule("fsm", .{
+        .source_file = .{.path = "src/main.zig"},
+    });
+
     const lib = b.addStaticLibrary(.{
         .name = "zigfsm",
         .root_source_file = .{
@@ -25,6 +29,7 @@ pub fn build(b: *std.build.Builder) void {
         .root_source_file = .{ .path = "src/benchmark.zig" },
         .optimize = std.builtin.Mode.ReleaseFast,
     });
+    benchmark.addModule("fsm", fsm_mod);
 
     b.installArtifact(benchmark);
 

--- a/src/benchmark.zig
+++ b/src/benchmark.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const zigfsm = @import("main.zig");
+const zigfsm = @import("fsm");
 
 // Run with `zig build benchmark`
 pub fn main() !void {


### PR DESCRIPTION
- Added addModule and create the fsm_mod
- Benchmark now uses the module instead of relative path
- Added a gitignore so zig-cache and zig-out are not possible to be commited by accident