### PR TITLE
Update build.zig to export zigfsm for other build.zigs

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,6 +7,7 @@
 //!
 //! SPDX-License-Identifier: MIT
 const std = @import("std");
+pub const zigfsm = @import("src/main.zig");
 
 pub fn build(b: *std.Build) void {
     const target = b.standardTargetOptions(.{});


### PR DESCRIPTION
sources:
 
- https://zig.news/liyu1981/how-to-use-your-fav-pkg-in-buildzig-3ni8
- https://ziggit.dev/t/can-i-use-packages-inside-build-zig/2892/2

child build.zig export: 

https://github.com/liyu1981/zcmd.zig/blob/ef24428acabe2c8b83252a011dc1e75f0d260c42/build.zig#L3

parent build.zig import:

https://github.com/liyu1981/kcov/blob/331d207908ff0518c18282d04ed029b35ff74bbc/build.zig#L2