### PR TITLE
Fix alignment error in Interface.downcast when compiling for 32-bit 

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -644,7 +644,7 @@ pub const Interface = struct {
     /// if there's a mismatch. When this convention doesn't work, use @fieldParentPtr directly.
     pub fn downcast(comptime Implementer: type, interface_ref: anytype) *Implementer {
         const field_name = comptime std.meta.fieldNames(Implementer).*[0];
-        return @fieldParentPtr(field_name, interface_ref);
+        return @alignCast(@fieldParentPtr(field_name, interface_ref));
     }
 
     /// Instantiates an interface type and populates its function pointers to point to


### PR DESCRIPTION
Got this error when my struct became 8-aligned:
```
❯ zig build
install
└─ compile exe fw.elf Debug thumb-freestanding-eabihf 1 errors
<cache>/zigfsm-0.2.0-9VW4ufo6AQDk-HL7-JMc-XNgKRXzkeoNdDzrMtg8eF45/src/main.zig:647:16: error: @fieldParentPtr increases pointer alignment
        return @fieldParentPtr(field_name, interface_ref);
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<cache>/zigfsm-0.2.0-9VW4ufo6AQDk-HL7-JMc-XNgKRXzkeoNdDzrMtg8eF45/src/main.zig:647:16: note: '*align(4) Bldc' has alignment '4'
<cache>/zigfsm-0.2.0-9VW4ufo6AQDk-HL7-JMc-XNgKRXzkeoNdDzrMtg8eF45/src/main.zig:647:16: note: '*Bldc' has alignment '8'
<cache>/zigfsm-0.2.0-9VW4ufo6AQDk-HL7-JMc-XNgKRXzkeoNdDzrMtg8eF45/src/main.zig:647:16: note: use @alignCast to assert pointer alignment
referenced by:
    onTransition: src/Bldc.zig:97:50
    make [inlined]: <cache>/zigfsm-0.2.0-9VW4ufo6AQDk-HL7-JMc-XNgKRXzkeoNdDzrMtg8eF45/src/main.zig:656:44
    init [inlined]: src/Bldc.zig:37:46
    bldc: src/Starter.zig:3:34
    8 reference(s) hidden; use '-freference-trace=12' to see all references
error: the following command failed with 1 compilation errors:
<toolchain>/zig build-exe ...
```

Found this: https://ziggit.dev/t/is-aligncast-necessary-with-fieldparentptr/11902/2
and this is my case (32-bit cortex-m4)

With `@alignCast` my code compiles and works as before